### PR TITLE
Specify environment variable separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It should be noted although there are better options out there, there isn't a re
 the loader to handle all of your imports everyday. The Canvas Data Loader could for example handle your
 imports at first, and then later off be handed to a more stable process.
 
-## Suppport ##
+## Support ##
 
 Although this is under the Instructure Repo this is purely an example application, and as such is not fully supported by Instructure.
 
@@ -32,6 +32,26 @@ are not using linux.
   * `crontab -e`
   * Enter on it's own line, replacing the path to your importer: `0 * * * * cd <my_cdl_location> && RUST_LOG=info ./target/release/cdl-runner > /var/log/cdl-log 2>&1`
 * Tadah!
+
+### Configuration Using Environment Variables
+
+Configuration can also be done using environment variables instead of, or in addition to the `./config/local.toml` file. For example, you may wish to use environment variables for the API key/secret and use the file for the remaining configuration.
+
+Example:
+
+`export cdl__canvasdataauth__api_key=abcdefg123456`
+`export cdl__canvasdataauth__api_secret=123456abcdefg`
+
+Possible environment variables:
+
+- `cdl__canvasdataauth__api_key`
+- `cdl__canvasdataauth__api_secret`
+- `cdl__database__db_type`
+- `cdl__database__url` 
+- `cdl__only_load_final`
+- `cdl__rocksdb_location`
+- `cdl__save_location`
+- `cdl__skip_historical_imports`
 
 ## License ##
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -65,9 +65,11 @@ impl Settings {
     base_configuration
       .merge(File::with_name("config/local").required(false))
       .expect("Transient error getting local configuration.");
-
+    
+    let mut env = Environment::with_prefix("cdl");
+    env.separator("__".to_string());
     base_configuration
-      .merge(Environment::with_prefix("cdl"))
+      .merge(env)
       .expect("Transient error getting environment variables");
 
     base_configuration.try_into().expect(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -67,7 +67,7 @@ impl Settings {
       .expect("Transient error getting local configuration.");
     
     let mut env = Environment::with_prefix("cdl");
-    env.separator("__".to_string());
+    env.separator("__".to_owned());
     base_configuration
       .merge(env)
       .expect("Transient error getting environment variables");


### PR DESCRIPTION
## Motivation ##

I was attempting to deploy Canvas Data Loader in a Docker container that uses environment variables for configuration. The default separator in config-rs for environment variables is `_`. This causes problems with hierarchical configuration. For example, cdl_canvasdataauth_api_secret is parsed as canvasdataauth.api.secret.

I've specified the separator to be `__` such that cdl__canvasdataauth__api_secret parses as canvasdataauth.api_secret

## Test Plan ##

- Confirm that environment variables are parsed properly.
- Confirm that there is no impact on default/local file configuration.

## Next Steps ##

cargo test passes (but I didn't add new tests, so that's not surprising)