### PR TITLE
copy the default config into docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ FROM debian:stretch-slim
 
 RUN apt-get update && apt-get -y --no-install-recommends install libssl1.1 ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=cdl-build /tmp/canvas-data-loader/target/release/cdl-runner .
+COPY ./config ./config
 
 ENV RUST_LOG info
 CMD ./cdl-runner


### PR DESCRIPTION
I found that if I'm using the environment variables to configure the docker instance I still need to copy in the default config, this just saves a step when deploying.